### PR TITLE
feat: Expose close and clearToasts functions to programmatically close the toasts

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -62,7 +62,7 @@ export default defineComponent({
 </script>
 ```
 
-## 自定义
+## 具体用法
 
 
 `createToast` 方法接受两个参数:
@@ -101,21 +101,55 @@ export default defineComponent({
   ```
 - **第二个参数**: 第二个参数是options，可以自定义提醒框。
 
+  | name        | type           | default  | description |
+  | ------------- |:-------------:| -----:| -----:|
+  | type      | 'info', 'danger', 'warning', 'success', 'default' | 'default' | 给与不同的样式 |
+  | timeout      | number      |   5000 | 自定义多少ms后关闭
+  | position      | 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'top-center', 'bottom-center' |   'top-right' | 自定义提醒框位置 |
+  | showCloseButton | boolean      |    true | 显示关闭按钮 |
+  | showIcon | boolean      |    false | 显示图标 |
+  | transition | 'bounce', 'zoom', 'slide' | 'bounce' | 自定义动画 |
+  | hideProgressBar | boolean      |    false | 关闭进度条 |
+  | swipeClose | boolean      |    true | 是否允许滑动关闭 |
+  | toastBackgroundColor | string      | default color | 自定义背景颜色 |
+  | onClose | function      | N/A | 这个方法会在提醒框消失时调用 |
 
-Options:
+- **以编程的方式关闭提醒框**
+  `createToast`函数会返回一个对象，对象中包含一个叫`close`的函数。调用`close`函数会关闭所属提醒框，请看下面例子。
+  ```ts
+      import { createToast } from 'mosha-vue-toastify';
+      import CustomizedContent from "./CustomizedContent.vue";
+      import 'mosha-vue-toastify/dist/style.css';
 
-| name        | type           | default  | description |
-| ------------- |:-------------:| -----:| -----:|
-| type      | 'info', 'danger', 'warning', 'success', 'default' | 'default' | 给与不同的样式 |
-| timeout      | number      |   5000 | 自定义多少ms后关闭
-| position      | 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'top-center', 'bottom-center' |   'top-right' | 自定义提醒框位置 |
-| showCloseButton | boolean      |    true | 显示关闭按钮 |
-| showIcon | boolean      |    false | 显示图标 |
-| transition | 'bounce', 'zoom', 'slide' | 'bounce' | 自定义动画 |
-| hideProgressBar | boolean      |    false | 关闭进度条 |
-| swipeClose | boolean      |    true | 是否允许滑动关闭 |
-| toastBackgroundColor | string      | default color | 自定义背景颜色 |
-| onClose | function      | N/A | 这个方法会在提醒框消失时调用 |
+      export default defineComponent({
+        setup () {
+          const toast = () => {
+              // 调用close能直接关闭提醒框
+              const { close } = createToast(CustomizedContent)
+              // close()
+          }
+
+          return { toast }
+        }
+      })
+  ```
+  调用`clearToasts`函数会关闭页面上所有的提醒框。
+  ```ts
+      import { createToast, clearToasts } from 'mosha-vue-toastify';
+      import CustomizedContent from "./CustomizedContent.vue";
+      import 'mosha-vue-toastify/dist/style.css';
+
+      export default defineComponent({
+        setup () {
+          const clear = () => {
+            // 关闭所以提醒框
+            clearToasts()
+          }
+
+          return { clear }
+        }
+      })
+  ```
 
 ## 支持一下吧
 

--- a/README.md
+++ b/README.md
@@ -102,21 +102,56 @@ The `createToast` function accepts 2 arguments:
 
 - **Second argument**: the second argument is an options object.
 
+    | name        | type           | default  | description |
+    | ------------- |:-------------:| -----:| -----:|
+    | type      | 'info', 'danger', 'warning', 'success', 'default' | 'default' | Give the toast different styles and icons. |
+    | timeout      | number      |   5000 | How many ms you want the toggle to close itself?
+    | position      | 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'top-center', 'bottom-center' |   'top-right' | Where do you want the toast to appear? |
+    | showCloseButton | boolean      |    true | Do you wanna show the close button ? |
+    | showIcon | boolean      |    false | Do you wanna show the icon ? |
+    | transition | 'bounce', 'zoom', 'slide' | 'bounce' | Which animation do you want? |
+    | hideProgressBar | boolean      |    false | Do we wanna hide the fancy progress bar? |
+    | swipeClose | boolean      |    true | Allows the user swipe close the toast |
+    | toastBackgroundColor | string      | default color | Customize the background color of the toast. |
+    | onClose | function      | N/A | This function will be called at the end of the toast's lifecycle|
 
-Options:
+- **Programatically closing**
+  The `createToast` function returns an object that contains a `close` funtion that allows the user to programatically dismiss the toast. See below:
+  ```ts
+      import { createToast } from 'mosha-vue-toastify';
+      import CustomizedContent from "./CustomizedContent.vue";
+      import 'mosha-vue-toastify/dist/style.css';
 
-| name        | type           | default  | description |
-| ------------- |:-------------:| -----:| -----:|
-| type      | 'info', 'danger', 'warning', 'success', 'default' | 'default' | Give the toast different styles and icons. |
-| timeout      | number      |   5000 | How many ms you want the toggle to close itself?
-| position      | 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'top-center', 'bottom-center' |   'top-right' | Where do you want the toast to appear? |
-| showCloseButton | boolean      |    true | Do you wanna show the close button ? |
-| showIcon | boolean      |    false | Do you wanna show the icon ? |
-| transition | 'bounce', 'zoom', 'slide' | 'bounce' | Which animation do you want? |
-| hideProgressBar | boolean      |    false | Do we wanna hide the fancy progress bar? |
-| swipeClose | boolean      |    true | Allows the user swipe close the toast |
-| toastBackgroundColor | string      | default color | Customize the background color of the toast. |
-| onClose | function      | N/A | This function will be called at the end of the toast's lifecycle|
+      export default defineComponent({
+        setup () {
+          const toast = () => {
+              // This close function can be used to close the toast
+              const { close } = createToast(CustomizedContent)
+              // close()
+          }
+
+          return { toast }
+        }
+      })
+  ```
+  To clear all the toasts, use the `clearToasts` function. See below
+  ```ts
+      import { createToast, clearToasts } from 'mosha-vue-toastify';
+      import CustomizedContent from "./CustomizedContent.vue";
+      import 'mosha-vue-toastify/dist/style.css';
+
+      export default defineComponent({
+        setup () {
+          const clear = () => {
+            // clears all the toasts
+            clearToasts()
+          }
+
+          return { clear }
+        }
+      })
+  ```
+
 
 ## Support
 

--- a/docs/.vitepress/theme/components/Code.vue
+++ b/docs/.vitepress/theme/components/Code.vue
@@ -104,13 +104,19 @@
       >
         Show toast!
       </button>
+      <button
+        @click="clearAll"
+        class="w-full antialiased text-lg h-12 mt-5 bg-indigo-500 text-white px-2 py-1 rounded hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-opacity-50"
+      >
+        Clear All
+      </button>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, ref, watchEffect } from "vue";
-import { createToast } from "../../../../lib/main";
+import { clearToasts, createToast } from "../../../../lib/main";
 import "../../../../lib/index.scss";
 import InputGroup from "./InputGroup.vue";
 import RadioGroup from "./RadioGroup.vue";
@@ -250,6 +256,11 @@ export default defineComponent({
       output += "</div>";
       return output;
     });
+
+    const clearAll = () => {
+      clearToasts()
+    }
+
     return {
       text,
       description,
@@ -267,6 +278,7 @@ export default defineComponent({
       showIcon,
       swipeClose,
       toastBackgroundColor,
+      clearAll
     };
   },
 });

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,6 +1,7 @@
-# Configuration
+## Configuration
 
 The `createToast` function accepts 2 arguments:
+
 - **First argument**: 
   - It can be just a string or a object like this: `{ title: 'some title', description: 'some good description'}`. By the way, description now accepts html, for more customization, we recommand trying out the custom component approach
   - It can also accept a Vue 3 component or a VNode if you need more customization, e.g.
@@ -33,21 +34,56 @@ The `createToast` function accepts 2 arguments:
         return { toast }
       }
     })
-  ``` 
+  ```
+
 - **Second argument**: the second argument is an options object.
 
+    | name        | type           | default  | description |
+    | ------------- |:-------------:| -----:| -----:|
+    | type      | 'info', 'danger', 'warning', 'success', 'default' | 'default' | Give the toast different styles and icons. |
+    | timeout      | number      |   5000 | How many ms you want the toggle to close itself?
+    | position      | 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'top-center', 'bottom-center' |   'top-right' | Where do you want the toast to appear? |
+    | showCloseButton | boolean      |    true | Do you wanna show the close button ? |
+    | showIcon | boolean      |    false | Do you wanna show the icon ? |
+    | transition | 'bounce', 'zoom', 'slide' | 'bounce' | Which animation do you want? |
+    | hideProgressBar | boolean      |    false | Do we wanna hide the fancy progress bar? |
+    | swipeClose | boolean      |    true | Allows the user swipe close the toast |
+    | toastBackgroundColor | string      | default color | Customize the background color of the toast. |
+    | onClose | function      | N/A | This function will be called at the end of the toast's lifecycle|
 
-Options:
+- **Programatically closing**
+  The `createToast` function returns an object that contains a `close` funtion that allows the user to programatically dismiss the toast. See below:
+  ```ts
+      import { createToast } from 'mosha-vue-toastify';
+      import CustomizedContent from "./CustomizedContent.vue";
+      import 'mosha-vue-toastify/dist/style.css';
 
-| name        | type           | default  | description |
-| ------------- |:-------------:| -----:| -----:|
-| type      | 'info', 'danger', 'warning', 'success', 'default' | 'default' | Give the toast different styles and icons. |
-| timeout      | number      |   5000 | How many ms you want the toggle to close itself?
-| position      | 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'top-center', 'bottom-center' |   'top-right' | Where do you want the toast to appear? |
-| showCloseButton | boolean      |    true | Do you wanna show the close button ? |
-| showIcon | boolean      |    false | Do you wanna show the icon ? |
-| transition | 'bounce', 'zoom', 'slide' | 'bounce' | Which animation do you want? |
-| hideProgressBar | boolean      |    false | Do we wanna hide the fancy progress bar? |
-| swipeClose | boolean      |    true | Allows the user swipe close the toast |
-| toastBackgroundColor | string      | default color | Customize the background color of the toast. |
-| onClose | function      | N/A | This function will be called at the end of the toast's lifecycle|
+      export default defineComponent({
+        setup () {
+          const toast = () => {
+              // This close function can be used to close the toast
+              const { close } = createToast(CustomizedContent)
+              // close()
+          }
+
+          return { toast }
+        }
+      })
+  ```
+  To clear all the toasts, use the `clearToasts` function. See below
+  ```ts
+      import { createToast, clearToasts } from 'mosha-vue-toastify';
+      import CustomizedContent from "./CustomizedContent.vue";
+      import 'mosha-vue-toastify/dist/style.css';
+
+      export default defineComponent({
+        setup () {
+          const clear = () => {
+            // clears all the toasts
+            clearToasts()
+          }
+
+          return { clear }
+        }
+      })
+  ```

--- a/examples/vite-sample/src/components/HelloWorld.vue
+++ b/examples/vite-sample/src/components/HelloWorld.vue
@@ -77,7 +77,10 @@ export default defineComponent({
       }, 1)
     }
     const tr = () => {
-      createToast('content here')
+      const { close } = createToast('content here')
+      setTimeout(() => {
+        close()
+      }, 500)
     }
 
     const tl = () => {

--- a/examples/vite-sample/src/components/HelloWorld.vue
+++ b/examples/vite-sample/src/components/HelloWorld.vue
@@ -7,13 +7,14 @@
     <button @click="bl">bottom-left</button>
     <button @click="tc">top-center</button>
     <button @click="bc">bottom-center</button>
+    <button @click="clear">clear toasts</button>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 import '../../../../lib/index.scss'
-import { createToast, withProps } from '../../../../lib/main'
+import { clearToasts, createToast, withProps } from '../../../../lib/main'
 import Test from './Test.vue'
 
 export default defineComponent({
@@ -64,20 +65,21 @@ export default defineComponent({
               )
             }, 1),
               setTimeout(() => {
-                createToast(
-                  withProps(Test, { title: 'Custom Component!'}),
-                  {
-                    position: 'top-center',
-                    timeout: 8000,
-                  }
-                )
+                createToast(withProps(Test, { title: 'Custom Component!' }), {
+                  position: 'top-center',
+                  timeout: 8000
+                })
               }, 1)
           }, 1)
         }, 1)
       }, 1)
     }
     const tr = () => {
-      const { close } = createToast('content here')
+      const { close } = createToast('content here', {
+        onClose: () => {
+          console.log('log')
+        }
+      })
       setTimeout(() => {
         close()
       }, 500)
@@ -147,7 +149,11 @@ export default defineComponent({
         }
       })
     }
-    return { tr, tl, br, bl, tc, bc, all }
+
+    const clear = () => {
+      clearToasts()
+    }
+    return { tr, tl, br, bl, tc, bc, all, clear }
   }
 })
 </script>

--- a/lib/components/MToast.vue
+++ b/lib/components/MToast.vue
@@ -5,7 +5,7 @@
       class="mosha__toast"
       :style="[style, swipeStyle]"
       :class="toastBackgroundColor ? null : type"
-      @mouseenter="stopTimer"
+      @mouseenter="onMouseEnter"
       @mouseleave="onMouseLeave"
       @touchstart="onTouchStart"
       @mousedown="onMouseDown"
@@ -61,6 +61,7 @@ import { Position, ToastType, TransitionType } from '../types'
 import useTimer from '../hooks/useTimer'
 import useTransitionType from '../hooks/useTransitionType'
 import useCustomStyle from '../hooks/useCustomStyle'
+import useScreenSize from '../hooks/useScreenSize'
 import useSwipe from '../hooks/useSwipe'
 import MIcon from './MIcon.vue'
 
@@ -130,10 +131,12 @@ export default defineComponent({
     transition: {
       type: String as PropType<TransitionType>,
       default: 'bounce'
-    }
+    },
   },
   setup(props, ctx) {
     const style = ref<CSSProperties>()
+
+    const { width } = useScreenSize()
 
     const { swipedDiff, startSwipeHandler, swipeStyle, cleanUpMove } = useSwipe(
       props.position,
@@ -163,8 +166,8 @@ export default defineComponent({
       }
     }
 
-    const stopTimer = () => {
-      if (props.timeout > 0) {
+    const onMouseEnter = () => {
+      if (props.timeout > 0 && width.value > 425) {
         stop()
       }
     }
@@ -199,14 +202,14 @@ export default defineComponent({
       style,
       transitionType,
       startTimer,
-      stopTimer,
       progress,
       onTouchStart,
       onMouseLeave,
       onMouseDown,
       swipeStyle,
       isSlotPassed,
-      isDescriptionHtml
+      isDescriptionHtml,
+      onMouseEnter,
     }
   }
 })

--- a/lib/createToast.ts
+++ b/lib/createToast.ts
@@ -14,6 +14,13 @@ const toasts: Record<Position, ToastObject[]> = {
 
 let toastId = 0
 
+/**
+ * Creates a toast based on content and options
+ * 
+ * @param content can be a content object with title and description or a Vue component or just plain text.
+ * @param options options for the toast, please refer to the README for more details
+ * @returns an object contains the close function that can be used to dismiss the toast
+ */
 export const createToast = (
   content: ToastContent,
   options?: ToastOptions
@@ -199,4 +206,20 @@ export const close = (id: number, position: Position): void => {
     render(null, container)
     document.body.removeChild(container)
   }, 1000)
+}
+
+/**
+ * Clear all the toasts
+ */
+export const clearToasts = (): void => {
+  Object.entries(toasts).forEach(([key, val]) => {
+    if (val.length > 0) {
+      const ids = val.map(toast => {
+        return (toast.toastVNode.props as any).id
+      })
+      ids.forEach(id => {
+        close(id, key as Position)
+      })
+    }
+  })
 }

--- a/lib/hooks/useScreenSize.ts
+++ b/lib/hooks/useScreenSize.ts
@@ -1,0 +1,36 @@
+import { onMounted, onUnmounted, Ref, ref } from 'vue';
+import { debounce } from '../util'
+const useScreenSize = (): {
+  width: Ref<number>,
+  height: Ref<number>
+} => {
+  const width = ref<number>(-1);
+  const height = ref<number>(-1);
+
+
+  const resizeHandler = (e: Event) => {
+    if (e !== null) {
+      width.value = (e.currentTarget as Window).innerWidth
+      height.value = (e.currentTarget as Window).innerHeight
+    }
+  }
+
+  onMounted(() => {
+    if (window.innerWidth > 0) {
+      width.value = window.innerWidth
+      height.value = window.innerHeight
+    }
+    window.addEventListener("resize", debounce(resizeHandler))
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener("resize", debounce(resizeHandler))
+  })
+
+  return {
+    width,
+    height
+  }
+}
+
+export default useScreenSize;

--- a/lib/hooks/useTimer.ts
+++ b/lib/hooks/useTimer.ts
@@ -28,7 +28,7 @@ const useTimer = (
     intervalId.value = setInterval(() => {
       progress.value--
       // have to -2 because of the transition time
-    }, delay / 100 - 2)
+    }, (delay / 100) - 5)
     timerId.value = setTimeout(callback, remainingTime.value)
   }
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -2,7 +2,7 @@ import { App } from '@vue/runtime-core'
 import { createToast } from './createToast'
 import './index.scss'
 
-export { createToast } from './createToast'
+export { createToast, clearToasts } from './createToast'
 export { withProps } from './util'
 export * from './types'
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -3,3 +3,15 @@ import { Component, createVNode, VNode } from 'vue';
 export const withProps = (component: Component, props: (Record<string, unknown>)): VNode => {
   return createVNode(component, props);
 }
+
+export const debounce = <T extends (...args: any[]) => any>(fn: T, delay = 300) => {
+  let timeoutId: number | undefined = undefined
+
+  return (...args: any[]) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+      timeoutId = undefined
+    }
+    timeoutId = setTimeout(() => fn(...args), delay)
+  }
+}


### PR DESCRIPTION
# Changes
- Add `close` and `clearToasts` functions to allow programmatically closing
- Update the docs
- Disabled hover pausing the progress bar on mobile